### PR TITLE
2 feat 채팅방 목록 조회 검색 api

### DIFF
--- a/src/main/java/com/test/imessagesbackend/common/entity/BaseEntity.java
+++ b/src/main/java/com/test/imessagesbackend/common/entity/BaseEntity.java
@@ -1,0 +1,19 @@
+package com.test.imessagesbackend.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/test/imessagesbackend/common/error/code/ErrorCode.java
+++ b/src/main/java/com/test/imessagesbackend/common/error/code/ErrorCode.java
@@ -1,0 +1,62 @@
+package com.test.imessagesbackend.common.error.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+    // 성공 (2xx)
+    OK(HttpStatus.OK, 2000, "요청이 성공적으로 처리되었습니다."),
+    CREATED(HttpStatus.CREATED, 2001, "리소스가 성공적으로 생성되었습니다."),
+
+    // 클라이언트 오류 (4xx)
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, 4000, "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 4001, "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, 4003, "접근 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, 4004, "요청한 리소스를 찾을 수 없습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, 4005, "지원하지 않는 HTTP 메소드입니다."),
+    CONFLICT(HttpStatus.CONFLICT, 4009, "리소스 충돌이 발생했습니다."),
+
+    // 시스템 오류 (5xx)
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 내부 오류가 발생했습니다."),
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, 5003, "서비스를 일시적으로 사용할 수 없습니다."),
+    DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5001, "데이터베이스 오류가 발생했습니다."),
+    EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5002, "외부 API 호출 중 오류가 발생했습니다."),
+
+    // 인증/인가 관련 (41xx)
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 4100, "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, 4101, "만료된 토큰입니다."),
+    INSUFFICIENT_PERMISSIONS(HttpStatus.FORBIDDEN, 4102, "필요한 권한이 부족합니다."),
+
+    // Room 관련 (42xx)
+    ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, 4200, "요청한 방을 찾을 수 없습니다."),
+    ROOM_FULL(HttpStatus.BAD_REQUEST, 4201, "방이 가득 찼습니다."),
+    ROOM_CLOSED(HttpStatus.BAD_REQUEST, 4202, "이미 닫힌 방입니다."),
+    INVALID_ROOM_PASSWORD(HttpStatus.UNAUTHORIZED, 4203, "방 비밀번호가 올바르지 않습니다."),
+
+    // User 관련 (43xx)
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 4300, "사용자를 찾을 수 없습니다."),
+    USER_ALREADY_EXISTS(HttpStatus.CONFLICT, 4301, "이미 존재하는 사용자입니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, 4302, "잘못된 비밀번호입니다."),
+    INACTIVE_USER(HttpStatus.FORBIDDEN, 4303, "비활성화된 사용자입니다."),
+
+    // Message 관련 (44xx)
+    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, 4400, "메시지를 찾을 수 없습니다."),
+    MESSAGE_DELETED(HttpStatus.BAD_REQUEST, 4401, "삭제된 메시지입니다."),
+
+    // 입력값 검증 관련 (45xx)
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, 4500, "유효하지 않은 입력값입니다."),
+    MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, 4501, "필수 필드가 누락되었습니다."),
+    INVALID_FORMAT(HttpStatus.BAD_REQUEST, 4502, "잘못된 형식입니다."),
+    INVALID_LENGTH(HttpStatus.BAD_REQUEST, 4503, "길이가 유효하지 않습니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final int errorCode;
+    private final String description;
+
+
+
+}

--- a/src/main/java/com/test/imessagesbackend/common/error/exception/BaseException.java
+++ b/src/main/java/com/test/imessagesbackend/common/error/exception/BaseException.java
@@ -1,0 +1,16 @@
+package com.test.imessagesbackend.common.error.exception;
+
+import com.test.imessagesbackend.common.error.code.ErrorCode;
+
+public abstract class BaseException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BaseException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/test/imessagesbackend/common/error/exception/RoomNotFoundException.java
+++ b/src/main/java/com/test/imessagesbackend/common/error/exception/RoomNotFoundException.java
@@ -1,0 +1,13 @@
+package com.test.imessagesbackend.common.error.exception;
+
+import com.test.imessagesbackend.common.error.code.ErrorCode;
+
+public class RoomNotFoundException extends BaseException {
+    public RoomNotFoundException(Long roomId) {
+        super(ErrorCode.ROOM_NOT_FOUND, "Room not found with id: " + roomId);
+    }
+
+    public RoomNotFoundException(Long roomId, String message) {
+        super(ErrorCode.ROOM_NOT_FOUND, message + ": " + roomId);
+    }
+}

--- a/src/main/java/com/test/imessagesbackend/common/error/exceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/test/imessagesbackend/common/error/exceptionHandler/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.test.imessagesbackend.common.error.exceptionHandler;
+
+import com.test.imessagesbackend.common.error.code.ErrorCode;
+import com.test.imessagesbackend.common.error.exception.BaseException;
+import com.test.imessagesbackend.common.response.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBaseException(BaseException ex) {
+        HttpStatus status = resolveStatusFromErrorCode(ex.getErrorCode());
+        return ResponseEntity
+                .status(status)
+                .body(ApiResponse.error(ex.getErrorCode(), ex.getMessage()));
+    }
+
+    // HTTP 상태 코드 결정 헬퍼 메소드
+    private HttpStatus resolveStatusFromErrorCode(ErrorCode errorCode) {
+        // ErrorCode에 따라 적절한 HTTP 상태 코드 반환
+        switch (errorCode) {
+            case NOT_FOUND:
+            case USER_NOT_FOUND:
+            case ROOM_NOT_FOUND:
+                return HttpStatus.NOT_FOUND;
+            case BAD_REQUEST:
+            case INVALID_FORMAT:
+                return HttpStatus.BAD_REQUEST;
+            // 기타 다른 케이스들...
+            default:
+                return HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+    }
+
+    // 표준 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleGlobalException(Exception ex) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR,
+                        "서버 내부 오류가 발생했습니다."));
+    }
+}

--- a/src/main/java/com/test/imessagesbackend/common/response/ApiResponse.java
+++ b/src/main/java/com/test/imessagesbackend/common/response/ApiResponse.java
@@ -1,0 +1,59 @@
+package com.test.imessagesbackend.common.response;
+
+import com.test.imessagesbackend.common.error.code.ErrorCode;
+import lombok.Builder;
+import lombok.Getter;
+
+/*
+* API 응답 표준화 클래스
+* */
+
+@Builder
+@Getter
+public class ApiResponse<T> {
+    private Integer code;
+    private String message;
+    private T data;
+
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return ApiResponse.<T>builder()
+                .code(ErrorCode.OK.getErrorCode())
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return ApiResponse.<T>builder()
+                .code(ErrorCode.OK.getErrorCode())
+                .message(ErrorCode.OK.getDescription())
+                .data(data)
+                .build();
+    }
+
+    public static <T> ApiResponse<T> error(ErrorCode errorCode, String description) {
+        return ApiResponse.<T>builder()
+                .code(errorCode.getErrorCode())
+                .message(description)
+                .build();
+    }
+
+    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
+        return ApiResponse.<T>builder()
+                .code(errorCode.getErrorCode())
+                .message(errorCode.getDescription())
+                .build();
+    }
+
+    public static <T> ApiResponse<T> error(String description) {
+        return ApiResponse.<T>builder()
+                .code(ErrorCode.INTERNAL_SERVER_ERROR.getErrorCode())
+                .message(description)
+                .build();
+    }
+
+
+
+
+}

--- a/src/main/java/com/test/imessagesbackend/room/controller/RoomController.java
+++ b/src/main/java/com/test/imessagesbackend/room/controller/RoomController.java
@@ -1,0 +1,47 @@
+package com.test.imessagesbackend.room.controller;
+
+import com.test.imessagesbackend.common.error.exception.RoomNotFoundException;
+import com.test.imessagesbackend.common.response.ApiResponse;
+import com.test.imessagesbackend.room.dto.RoomResponse;
+import com.test.imessagesbackend.room.service.RoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@ResponseStatus(HttpStatus.OK)
+public class RoomController {
+
+    private final RoomService roomService;
+
+    /*
+    * 사용자가 속한 채팅방을 모두 조회
+    * room id가 파라미터로 왔을 경우 조회 조건에 추가
+    * */
+    @GetMapping("/rooms")
+    public ApiResponse<List<RoomResponse>> findAllRooms(@RequestParam(required = false) String search) {
+        Long id = 1L;
+        return ApiResponse.success(roomService.findRoomsByUserIdAndSearchKeyword(id, search));
+    }
+
+    /*
+     * 특정 room id의 채팅방 조회
+     * */
+    @GetMapping("/rooms/{roomId}")
+    public ApiResponse<RoomResponse> findRoomByUserIdAndRoomId(@PathVariable Long roomId){
+        Long id = 1L;
+        return ApiResponse.success(roomService.findRoomByUserIdAndRoomId(1L, roomId));
+    }
+
+    @PostMapping("/rooms")
+    public ApiResponse<RoomResponse> createChatRoom(){
+        String name = "고양이";
+
+        return ApiResponse.success(roomService.createRoom(1L, name));
+    }
+}

--- a/src/main/java/com/test/imessagesbackend/room/dto/RoomRequest.java
+++ b/src/main/java/com/test/imessagesbackend/room/dto/RoomRequest.java
@@ -1,0 +1,15 @@
+package com.test.imessagesbackend.room.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class RoomRequest {
+    private Long creatorId;
+
+}

--- a/src/main/java/com/test/imessagesbackend/room/dto/RoomResponse.java
+++ b/src/main/java/com/test/imessagesbackend/room/dto/RoomResponse.java
@@ -1,0 +1,25 @@
+package com.test.imessagesbackend.room.dto;
+
+import com.test.imessagesbackend.room.entity.Room;
+import com.test.imessagesbackend.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class RoomResponse {
+    private final Long id;
+    private final String name;
+    private final String creator;
+    private final List<Long> roomUsers;
+
+    @Builder
+    public RoomResponse(Long id, String name, String creator, List<Long> roomUsers) {
+        this.id = id;
+        this.name = name;
+        this.creator = creator;
+        this.roomUsers = roomUsers;
+    }
+}

--- a/src/main/java/com/test/imessagesbackend/room/entity/Room.java
+++ b/src/main/java/com/test/imessagesbackend/room/entity/Room.java
@@ -1,0 +1,49 @@
+package com.test.imessagesbackend.room.entity;
+
+import com.test.imessagesbackend.common.entity.BaseEntity;
+import com.test.imessagesbackend.message.entity.Message;
+import com.test.imessagesbackend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Room extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creator_id")
+    private User creator;
+
+    @OneToMany(mappedBy = "room")
+    private List<RoomUser> roomUsers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "room")
+    private List<Message> messages = new ArrayList<>();
+
+    public Room(User creator, String name) {
+        this.creator = creator;
+        this.name = name;
+    }
+}
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/com/test/imessagesbackend/room/entity/RoomUser.java
+++ b/src/main/java/com/test/imessagesbackend/room/entity/RoomUser.java
@@ -1,0 +1,37 @@
+package com.test.imessagesbackend.room.entity;
+
+import com.test.imessagesbackend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "room_user")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoomUser {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private Room room;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDateTime joinedAt;
+
+    public RoomUser(Room room, User user, LocalDateTime joinedAt) {
+        this.room = room;
+        this.user = user;
+        this.joinedAt = joinedAt;
+    }
+
+}

--- a/src/main/java/com/test/imessagesbackend/room/repository/RoomRepository.java
+++ b/src/main/java/com/test/imessagesbackend/room/repository/RoomRepository.java
@@ -1,0 +1,24 @@
+package com.test.imessagesbackend.room.repository;
+
+import com.test.imessagesbackend.room.entity.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface RoomRepository extends JpaRepository<Room, Long> {
+
+    @Query("SELECT ru.room FROM RoomUser ru WHERE ru.user.id = :userId " +
+            "AND (:search IS NULL OR ru.room.id = :search)")
+    List<Room> findRoomsByUserIdAndRoomId(Long userId, Long search);
+
+    Optional<Room> findById(Long roomId);
+
+    @Query("SELECT r FROM Room r JOIN r.roomUsers ru WHERE r.id = :roomId AND ru.user.id = :userId")
+    Optional<Room> findByUserIdAndRoomId(Long userId, Long roomId);
+
+
+}

--- a/src/main/java/com/test/imessagesbackend/room/repository/RoomUserRepository.java
+++ b/src/main/java/com/test/imessagesbackend/room/repository/RoomUserRepository.java
@@ -1,0 +1,10 @@
+package com.test.imessagesbackend.room.repository;
+
+import com.test.imessagesbackend.room.entity.RoomUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoomUserRepository extends JpaRepository<RoomUser, Long> {
+
+}

--- a/src/main/java/com/test/imessagesbackend/room/service/RoomService.java
+++ b/src/main/java/com/test/imessagesbackend/room/service/RoomService.java
@@ -1,0 +1,84 @@
+package com.test.imessagesbackend.room.service;
+
+import com.test.imessagesbackend.common.error.exception.RoomNotFoundException;
+import com.test.imessagesbackend.room.dto.RoomResponse;
+import com.test.imessagesbackend.room.entity.Room;
+import com.test.imessagesbackend.room.entity.RoomUser;
+import com.test.imessagesbackend.room.repository.RoomRepository;
+import com.test.imessagesbackend.room.repository.RoomUserRepository;
+import com.test.imessagesbackend.user.entity.User;
+import com.test.imessagesbackend.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RoomService {
+
+    private final RoomRepository roomRepository;
+    private final RoomUserRepository roomUserRepository;
+    private final UserRepository userRepository;
+
+    public List<RoomResponse> findRoomsByUserIdAndSearchKeyword(Long userId, String search) {
+        return roomRepository.findRoomsByUserIdAndRoomId(userId, search == null ? null : Long.parseLong(search))
+                .stream()
+                .map(room -> RoomResponse.builder()
+                        .id(room.getId())
+                        .name(room.getName())
+                        .creator(room.getCreator().getUserId())
+                        .roomUsers(room.getRoomUsers().stream()
+                                .map(roomUser -> roomUser.getUser().getId())
+                                .collect(Collectors.toList()))
+                        .build())
+                .toList();
+    }
+
+    public RoomResponse findRoomByUserIdAndRoomId(Long userId, Long roomId) {
+        return roomRepository.findByUserIdAndRoomId(userId, roomId)
+                .map(room -> {
+                    List<Long> roomUserIds = room.getRoomUsers().stream()
+                            .map(roomUser -> roomUser.getUser().getId())
+                            .collect(Collectors.toList());
+
+                    return RoomResponse.builder()
+                            .id(room.getId())
+                            .name(room.getName())
+                            .creator(room.getCreator().getUserId())
+                            .roomUsers(roomUserIds)
+                            .build();
+                })
+                .orElseThrow(() -> new RoomNotFoundException(roomId, "채팅방을 찾을 수 없습니다"));
+    }
+
+    @Transactional
+    public RoomResponse createRoom(Long userId, String roomName) {
+        // 생성자 정보로 Room 생성 (생성자 패턴 사용)
+        User creator = userRepository.findById(userId).get();
+        Room room = new Room(creator, roomName);
+
+        // 저장하여 ID 생성
+        Room savedRoom = roomRepository.save(room);
+
+        // 생성자를 첫 참여자로 추가 (생성자 패턴 사용)
+        RoomUser roomUser = new RoomUser(savedRoom, creator, LocalDateTime.now());
+        roomUserRepository.save(roomUser);
+
+        List<Long> roomUserIds = savedRoom.getRoomUsers().stream()
+                .map(user -> user.getUser().getId())
+                .collect(Collectors.toList());
+
+        return RoomResponse.builder()
+                .id(savedRoom.getId())
+                .name(savedRoom.getName())
+                .creator(savedRoom.getCreator().getUserId())
+                .roomUsers(roomUserIds)
+                .build();
+    }
+
+}

--- a/src/main/java/com/test/imessagesbackend/user/entity/User.java
+++ b/src/main/java/com/test/imessagesbackend/user/entity/User.java
@@ -1,0 +1,54 @@
+package com.test.imessagesbackend.user.entity;
+
+import com.test.imessagesbackend.common.entity.BaseEntity;
+import com.test.imessagesbackend.message.entity.Message;
+import com.test.imessagesbackend.room.entity.Room;
+import com.test.imessagesbackend.room.entity.RoomUser;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "\"user\"")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private String userId;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "profile_img_url")
+    private String profileImgUrl;
+
+    @OneToMany(mappedBy = "user")
+    private List<RoomUser> roomUsers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Message> messages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "creator")
+    private List<Room> createdRooms = new ArrayList<>();
+
+    @Builder
+    public User(String userId, String password, String profileImgUrl) {
+        this.userId = userId;
+        this.password = password;
+        this.profileImgUrl = profileImgUrl;
+    }
+}

--- a/src/main/java/com/test/imessagesbackend/user/repository/UserRepository.java
+++ b/src/main/java/com/test/imessagesbackend/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.test.imessagesbackend.user.repository;
+
+import com.test.imessagesbackend.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
# 💡 PR 요약

채팅방 기능 구현을 위한 기본 엔티티 및 채팅방 생성/조회 API 구현 (테스트용)

## 📝 작업 내용

### 도메인 엔티티 구현
- Room, User, RoomUser 엔티티 클래스 구현
- 채팅방과 사용자 간 다대다 관계 설계
- BaseEntity 추상 클래스 구현으로 공통 엔티티 속성 관리

### 채팅방 API 구현
- 채팅방 생성 API 구현
- 채팅방 조회 API 구현
- 요청/응답 DTO 설계

### 비즈니스 로직 구현
- RoomService에서 채팅방 생성/조회 로직 구현
- Repository 계층 구현

### 에러 처리 구조 구현
- BaseException 추상 클래스 구현으로 일관된 예외 처리 기반 마련
- ErrorCode 열거형 구현으로 에러 코드 및 메시지 표준화
- RoomNotFoundException 등 구체적인 예외 클래스 구현
- GlobalExceptionHandler 구현으로 전역 예외 처리

### 응답 구조 표준화
- ApiResponse 클래스 구현으로 일관된 API 응답 형식 제공

## 📋 관련 이슈

- Issue #2: 채팅방 목록 조회 검색 api

## 💬 참고 사항

- 현재 버전은 테스트용으로, 추후 추가 기능 및 예외 처리 보완 예정
- 실제 채팅 기능은 다음 PR에서 구현 예정