### PR TITLE
4 feat websocket 설정 및 테스트 엔드포인트 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'com.h2database:h2'
 	implementation 'com.google.code.gson:gson:2.10.1'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+	implementation 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/test/imessagesbackend/chat/config/WebSocketBroker.java
+++ b/src/main/java/com/test/imessagesbackend/chat/config/WebSocketBroker.java
@@ -1,0 +1,29 @@
+package com.test.imessagesbackend.chat.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Slf4j
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketBroker implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws/chat")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+        log.info("WebSocket endpoint registered: /ws/chat");
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub");
+        log.info("WebSocket broker configured with prefix: /pub, destination: /sub");
+    }
+}

--- a/src/main/java/com/test/imessagesbackend/chat/controller/ChatController.java
+++ b/src/main/java/com/test/imessagesbackend/chat/controller/ChatController.java
@@ -1,0 +1,33 @@
+package com.test.imessagesbackend.chat.controller;
+
+import com.test.imessagesbackend.message.dto.MessageRequest;
+import com.test.imessagesbackend.message.service.MessageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final MessageService messageService;
+
+    @MessageMapping("/chat")
+    public ResponseEntity<String> greeting(@RequestBody MessageRequest message) throws Exception {
+        log.info("Processing message for roomId: {}, content: {}",
+                message.getRoomId(), message.getContent());
+
+        messageService.saveMessage(message);
+
+        // 메시지를 해당 채팅방 구독자들에게 전송
+        messagingTemplate.convertAndSend("/sub/chat/" + message.getRoomId(), message);
+        log.info("Message sent to destination: /sub/chat/{}", message.getRoomId());
+        return ResponseEntity.ok("메시지 전송 완료");
+    }
+}

--- a/src/main/java/com/test/imessagesbackend/common/config/WebConfig.java
+++ b/src/main/java/com/test/imessagesbackend/common/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.test.imessagesbackend.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("https://i-messages.vercel.app/")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(false);  // credentials 사용 안 함
+    }
+}

--- a/src/main/java/com/test/imessagesbackend/common/error/exception/UserNotFountException.java
+++ b/src/main/java/com/test/imessagesbackend/common/error/exception/UserNotFountException.java
@@ -1,0 +1,13 @@
+package com.test.imessagesbackend.common.error.exception;
+
+import com.test.imessagesbackend.common.error.code.ErrorCode;
+
+public class UserNotFountException extends BaseException{
+    public UserNotFountException(Long userId) {
+        super(ErrorCode.USER_NOT_FOUND, "User found with id: " + userId);
+    }
+
+    public UserNotFountException(Long userId, String message) {
+        super(ErrorCode.USER_NOT_FOUND, message + ": " + userId);
+    }
+}

--- a/src/main/java/com/test/imessagesbackend/message/controller/MessageController.java
+++ b/src/main/java/com/test/imessagesbackend/message/controller/MessageController.java
@@ -1,0 +1,30 @@
+package com.test.imessagesbackend.message.controller;
+
+import com.test.imessagesbackend.common.response.ApiResponse;
+import com.test.imessagesbackend.message.dto.MessageResponse;
+import com.test.imessagesbackend.message.service.MessageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "메시지", description = "채팅방 메시지 정보 관련 API를 제공합니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+@ResponseStatus(HttpStatus.OK)
+public class MessageController {
+
+    private final MessageService messageService;
+
+    @Operation(summary = "특정 채팅방의 메시지 조회", description = "사용자가 속한 채팅방의 메시지를 조회합니다.")
+    @GetMapping("/rooms/{roomId}/messages")
+    public ApiResponse<List<MessageResponse>> getMessages(@Parameter(description = "조회할 roomId") @PathVariable Long roomId) {
+        Long userId = 1L;   // 로그인 구현 전까지 하드코딩
+        return ApiResponse.success(messageService.findMessageByRoomId(roomId));
+    }
+}

--- a/src/main/java/com/test/imessagesbackend/message/dto/MessageRequest.java
+++ b/src/main/java/com/test/imessagesbackend/message/dto/MessageRequest.java
@@ -1,0 +1,21 @@
+package com.test.imessagesbackend.message.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class MessageRequest {
+
+    @Schema(description = "채팅방 ID")
+    private Long roomId;
+
+    @Schema(description = "메시지 내용")
+    private String content;
+
+}

--- a/src/main/java/com/test/imessagesbackend/message/dto/MessageResponse.java
+++ b/src/main/java/com/test/imessagesbackend/message/dto/MessageResponse.java
@@ -1,0 +1,51 @@
+package com.test.imessagesbackend.message.dto;
+
+import com.test.imessagesbackend.message.entity.Message;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class MessageResponse {
+
+    @Schema(description = "채팅방 ID")
+    private final Long roomId;
+
+    @Schema(description = "현재 접속한 사용자 ID (메시지 발신/수신 여부 비교용)")
+    private final Long currentUserId;
+
+    @Schema(description = "메시지 ID")
+    private final Long id;
+
+    @Schema(description = "메시지 내용")
+    private final String content;
+
+    @Schema(description = "메시지 발신자 ID")
+    private final Long senderId;
+
+    @Schema(description = "메시지 생성 시간")
+    private final LocalDateTime createdAt;
+
+    @Builder
+    public MessageResponse(Long roomId, Long currentUserId, Long id, String content, Long senderId, LocalDateTime createdAt) {
+        this.roomId = roomId;
+        this.currentUserId = currentUserId;
+        this.id = id;
+        this.content = content;
+        this.senderId = senderId;
+        this.createdAt = createdAt;
+    }
+
+    public static MessageResponse toDto(Message message, Long currentUserId) {
+        return MessageResponse.builder()
+                .roomId(message.getRoom().getId())
+                .currentUserId(currentUserId)
+                .id(message.getId())
+                .content(message.getContent())
+                .senderId(message.getUser().getId())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/test/imessagesbackend/message/entity/Message.java
+++ b/src/main/java/com/test/imessagesbackend/message/entity/Message.java
@@ -1,0 +1,42 @@
+package com.test.imessagesbackend.message.entity;
+
+import com.test.imessagesbackend.common.entity.BaseEntity;
+import com.test.imessagesbackend.room.entity.Room;
+import com.test.imessagesbackend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Message extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 500, nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private Room room;
+
+    @Builder
+    private Message(String content, User user, Room room) {
+        this.content = content;
+        this.user = user;
+        this.room = room;
+    }
+
+    public static Message toEntity(String content, User user, Room room) {
+        return Message.builder()
+                .content(content)
+                .user(user)
+                .room(room)
+                .build();
+    }
+}

--- a/src/main/java/com/test/imessagesbackend/message/repository/MessageRepository.java
+++ b/src/main/java/com/test/imessagesbackend/message/repository/MessageRepository.java
@@ -1,0 +1,10 @@
+package com.test.imessagesbackend.message.repository;
+
+import com.test.imessagesbackend.message.entity.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+    List<Message> findByRoomId(Long roomId);
+}

--- a/src/main/java/com/test/imessagesbackend/message/service/MessageService.java
+++ b/src/main/java/com/test/imessagesbackend/message/service/MessageService.java
@@ -1,0 +1,51 @@
+package com.test.imessagesbackend.message.service;
+
+import com.test.imessagesbackend.common.error.exception.RoomNotFoundException;
+import com.test.imessagesbackend.common.error.exception.UserNotFountException;
+import com.test.imessagesbackend.message.dto.MessageRequest;
+import com.test.imessagesbackend.message.dto.MessageResponse;
+import com.test.imessagesbackend.message.entity.Message;
+import com.test.imessagesbackend.message.repository.MessageRepository;
+import com.test.imessagesbackend.room.entity.Room;
+import com.test.imessagesbackend.room.repository.RoomRepository;
+import com.test.imessagesbackend.user.entity.User;
+import com.test.imessagesbackend.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+
+    private final MessageRepository messageRepository;
+    private final UserRepository userRepository;
+    private final RoomRepository roomRepository;
+
+    public List<MessageResponse> findMessageByRoomId(Long roomId) {
+        return messageRepository.findByRoomId(roomId)
+                .stream()
+                .map(message -> MessageResponse.builder()
+                        .roomId(message.getRoom().getId())
+                        .id(message.getId())
+                        .content(message.getContent())
+                        .senderId(message.getUser().getId())
+                        .createdAt(message.getCreatedAt())
+                        .build())
+                .toList();
+    }
+
+    @Transactional
+    public void saveMessage(MessageRequest messageRequest) {
+        Long userId = 1L;
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFountException(userId));
+        Room room = roomRepository.findById(messageRequest.getRoomId())
+                .orElseThrow(() -> new RoomNotFoundException(messageRequest.getRoomId()));
+
+        Message message = Message.toEntity(messageRequest.getContent(), user, room);
+        messageRepository.save(message);
+    }
+}

--- a/src/main/java/com/test/imessagesbackend/room/controller/RoomController.java
+++ b/src/main/java/com/test/imessagesbackend/room/controller/RoomController.java
@@ -1,19 +1,21 @@
 package com.test.imessagesbackend.room.controller;
 
-import com.test.imessagesbackend.common.error.exception.RoomNotFoundException;
 import com.test.imessagesbackend.common.response.ApiResponse;
 import com.test.imessagesbackend.room.dto.RoomResponse;
 import com.test.imessagesbackend.room.service.RoomService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "채팅방", description = "채팅방 관련 API를 제공합니다.")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/chat")
 @ResponseStatus(HttpStatus.OK)
 public class RoomController {
 
@@ -23,8 +25,9 @@ public class RoomController {
     * 사용자가 속한 채팅방을 모두 조회
     * room id가 파라미터로 왔을 경우 조회 조건에 추가
     * */
+    @Operation(summary = "채팅방 목록 조회", description = "사용자가 속한 채팅방의 정보를 모두 조회합니다.")
     @GetMapping("/rooms")
-    public ApiResponse<List<RoomResponse>> findAllRooms(@RequestParam(required = false) String search) {
+    public ApiResponse<List<RoomResponse>> findAllRooms(@Parameter(description = "검색 키워드") @RequestParam(required = false) String search) {
         Long id = 1L;
         return ApiResponse.success(roomService.findRoomsByUserIdAndSearchKeyword(id, search));
     }
@@ -32,12 +35,14 @@ public class RoomController {
     /*
      * 특정 room id의 채팅방 조회
      * */
+    @Operation(summary = "특정 채팅방 조회", description = "사용자가 속한 특정 roomId의 채팅방 정보를 조회합니다.")
     @GetMapping("/rooms/{roomId}")
-    public ApiResponse<RoomResponse> findRoomByUserIdAndRoomId(@PathVariable Long roomId){
+    public ApiResponse<RoomResponse> findRoomByUserIdAndRoomId(@Parameter(description = "조회할 roomId") @PathVariable Long roomId){
         Long id = 1L;
         return ApiResponse.success(roomService.findRoomByUserIdAndRoomId(1L, roomId));
     }
 
+    @Operation(summary = "채팅방 생성", description = "채팅방을 생성합니다.")
     @PostMapping("/rooms")
     public ApiResponse<RoomResponse> createChatRoom(){
         String name = "고양이";

--- a/src/main/java/com/test/imessagesbackend/room/dto/RoomRequest.java
+++ b/src/main/java/com/test/imessagesbackend/room/dto/RoomRequest.java
@@ -1,15 +1,10 @@
 package com.test.imessagesbackend.room.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@AllArgsConstructor
 @Getter
 @Builder
 public class RoomRequest {
-    private Long creatorId;
 
 }

--- a/src/main/java/com/test/imessagesbackend/room/dto/RoomResponse.java
+++ b/src/main/java/com/test/imessagesbackend/room/dto/RoomResponse.java
@@ -2,6 +2,7 @@ package com.test.imessagesbackend.room.dto;
 
 import com.test.imessagesbackend.room.entity.Room;
 import com.test.imessagesbackend.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,16 +11,15 @@ import java.util.stream.Collectors;
 
 @Getter
 public class RoomResponse {
+    @Schema(description = "채팅방 ID")
     private final Long id;
+
+    @Schema(description = "채팅방 이름")
     private final String name;
-    private final String creator;
-    private final List<Long> roomUsers;
 
     @Builder
-    public RoomResponse(Long id, String name, String creator, List<Long> roomUsers) {
+    public RoomResponse(Long id, String name) {
         this.id = id;
         this.name = name;
-        this.creator = creator;
-        this.roomUsers = roomUsers;
     }
 }

--- a/src/main/java/com/test/imessagesbackend/room/service/RoomService.java
+++ b/src/main/java/com/test/imessagesbackend/room/service/RoomService.java
@@ -14,8 +14,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,10 +29,6 @@ public class RoomService {
                 .map(room -> RoomResponse.builder()
                         .id(room.getId())
                         .name(room.getName())
-                        .creator(room.getCreator().getUserId())
-                        .roomUsers(room.getRoomUsers().stream()
-                                .map(roomUser -> roomUser.getUser().getId())
-                                .collect(Collectors.toList()))
                         .build())
                 .toList();
     }
@@ -42,15 +36,10 @@ public class RoomService {
     public RoomResponse findRoomByUserIdAndRoomId(Long userId, Long roomId) {
         return roomRepository.findByUserIdAndRoomId(userId, roomId)
                 .map(room -> {
-                    List<Long> roomUserIds = room.getRoomUsers().stream()
-                            .map(roomUser -> roomUser.getUser().getId())
-                            .collect(Collectors.toList());
 
                     return RoomResponse.builder()
                             .id(room.getId())
                             .name(room.getName())
-                            .creator(room.getCreator().getUserId())
-                            .roomUsers(roomUserIds)
                             .build();
                 })
                 .orElseThrow(() -> new RoomNotFoundException(roomId, "채팅방을 찾을 수 없습니다"));
@@ -69,15 +58,9 @@ public class RoomService {
         RoomUser roomUser = new RoomUser(savedRoom, creator, LocalDateTime.now());
         roomUserRepository.save(roomUser);
 
-        List<Long> roomUserIds = savedRoom.getRoomUsers().stream()
-                .map(user -> user.getUser().getId())
-                .collect(Collectors.toList());
-
         return RoomResponse.builder()
                 .id(savedRoom.getId())
                 .name(savedRoom.getName())
-                .creator(savedRoom.getCreator().getUserId())
-                .roomUsers(roomUserIds)
                 .build();
     }
 

--- a/src/main/java/com/test/imessagesbackend/user/entity/User.java
+++ b/src/main/java/com/test/imessagesbackend/user/entity/User.java
@@ -24,8 +24,8 @@ public class User extends BaseEntity {
     @Column(name = "id", updatable = false)
     private Long id;
 
-    @Column(name = "user_id", nullable = false)
-    private String userId;
+    @Column(name = "email", nullable = false)
+    private String email;
 
     @Column(name = "password", nullable = false)
     private String password;
@@ -46,8 +46,7 @@ public class User extends BaseEntity {
     private List<Room> createdRooms = new ArrayList<>();
 
     @Builder
-    public User(String userId, String password, String profileImgUrl) {
-        this.userId = userId;
+    public User(String password, String profileImgUrl) {
         this.password = password;
         this.profileImgUrl = profileImgUrl;
     }


### PR DESCRIPTION
# 💡 PR 요약

실시간 채팅 기능의 기반이 되는 WebSocket 설정 및 메시지 송수신 로직 구현, Swagger 문서 보강 및 User 엔티티 수정 등 백엔드 핵심 기능 다수 반영

## 📝 작업 내용

- WebSocket 브로커 설정 (/ws/chat, /pub/chat, /sub/chat)
- 실시간 메시지 송수신 컨트롤러 및 메시지 저장 로직 구현
- 채팅 메시지 요청/응답 DTO 정의
- 특정 채팅방의 메시지를 조회하는 REST API 추가
- Swagger 어노테이션을 통한 채팅 API 문서화
- build.gradle에 MySQL 커넥터 의존성 추가
- UserNotFoundException 커스텀 예외 클래스 추가
- CORS 설정을 위한 WebConfig 클래스 추가 (프론트 도메인 허용)
- User 엔티티에서 로그인 식별자를 userId → email로 변경


## 📋 관련 이슈

- Issue #4: websocket-설정-및-테스트-엔드포인트-생성

## 💬 참고 사항

- Swagger 경로: /swagger-ui/index.html
- STOMP 기반 WebSocket 통신: 클라이언트는 /sub/chat 구독, /pub/chat로 메시지 발행
- 현재 메시지 저장은 단순 DB 저장으로, 향후 RabbitMQ 확장 고려